### PR TITLE
Add a 'terminate' flag for use in build events

### DIFF
--- a/src/PrivateGalleryCreator.csproj
+++ b/src/PrivateGalleryCreator.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>PrivateGalleryCreator</RootNamespace>
     <AssemblyName>PrivateGalleryCreator</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -48,6 +48,9 @@
     <Compile Include="Package.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="VsixManifestParser.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -6,25 +6,30 @@ using System.Text;
 
 namespace PrivateGalleryCreator
 {
-    class Program
+    internal class Program
     {
-        const string _xmlFileName = "feed.xml";
+        private const string _xmlFileName = "feed.xml";
         private static string _dir;
 
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
             _dir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
 
             GenerateAtomFeed();
 
-            if (args.Contains("--watch") || args.Contains("-w"))
+            switch (args)
             {
-                WatchDirectoryForChanges();
-            }
-            else
-            {
-                Console.WriteLine("Press any key to close...");
-                Console.ReadKey(true);
+                case var a when (a.Contains("--watch") || a.Contains("-w")):
+                    WatchDirectoryForChanges();
+                    break;
+
+                case var a when (a.Contains("--terminate") || a.Contains("-t")):
+                    break;
+
+                default:
+                    Console.WriteLine("Press any key to close...");
+                    Console.ReadKey(true);
+                    break;
             }
         }
 

--- a/src/app.config
+++ b/src/app.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
+  </startup>
+</configuration>


### PR DESCRIPTION
When used in a build event (to copy vsix to a known folder for use in a private dev vsix gallery) the Console.ReadKey statement was causing the build event to fail (returned error code 2)