### PR TITLE
Update FeedWriter.cs - use UtcNow for feed/updated timestamp

### DIFF
--- a/src/FeedWriter.cs
+++ b/src/FeedWriter.cs
@@ -23,7 +23,7 @@ namespace PrivateGalleryCreator
 
                 writer.WriteElementString("title", "VSIX Gallery");
                 writer.WriteElementString("id", "5a7c2525-ddd8-4c44-b2e3-f57ba01a0d81");
-                writer.WriteElementString("updated", DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+                writer.WriteElementString("updated", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"));
                 writer.WriteElementString("subtitle", "Add this feed to Visual Studio's extension manager from Tools -> Options -> Environment -> Extensions and Updates");
 
                 writer.WriteStartElement("link");


### PR DESCRIPTION
The timestamp in the 
<feed>
<updated>TIMESTAMP</updated>
...
</feed>
element was generated via DateTime.Now but rendered with a Z (zulu) suffix. 
Corrected so that DateTime.UtcNow is used.