### PR TITLE
Adding -output, -input, -recursive, -exclude options

### DIFF
--- a/src/FeedWriter.cs
+++ b/src/FeedWriter.cs
@@ -85,7 +85,7 @@ namespace PrivateGalleryCreator
             {
                 writer.WriteStartElement("link");
                 writer.WriteAttributeString("rel", "icon");
-                writer.WriteAttributeString("href", Path.GetDirectoryName( Program._outputFile) + "\\icons\\" + package.ID + Path.GetExtension(package.Icon));
+                writer.WriteAttributeString("href", "icons\\" + package.ID + Path.GetExtension(package.Icon));
                 writer.WriteEndElement(); // icon
             }
 

--- a/src/FeedWriter.cs
+++ b/src/FeedWriter.cs
@@ -78,14 +78,14 @@ namespace PrivateGalleryCreator
 
             writer.WriteStartElement("content");
             writer.WriteAttributeString("type", "application/octet-stream");
-            writer.WriteAttributeString("src", package.FileName);
+            writer.WriteAttributeString("src", package.FullPath);
             writer.WriteEndElement(); // content
 
             if (!string.IsNullOrEmpty(package.Icon))
             {
                 writer.WriteStartElement("link");
                 writer.WriteAttributeString("rel", "icon");
-                writer.WriteAttributeString("href", "icons/" + package.ID + Path.GetExtension(package.Icon));
+                writer.WriteAttributeString("href", Path.GetDirectoryName( Program._outputFile) + "\\icons\\" + package.ID + Path.GetExtension(package.Icon));
                 writer.WriteEndElement(); // icon
             }
 

--- a/src/Package.cs
+++ b/src/Package.cs
@@ -8,6 +8,7 @@ namespace PrivateGalleryCreator
     {
         public Package(string fileName)
         {
+            FullPath = fileName;
             FileName = Path.GetFileName(fileName);
         }
 
@@ -29,6 +30,7 @@ namespace PrivateGalleryCreator
 		public string Repo { get; set; }
 		public string IssueTracker { get; set; }
         public ExtensionList ExtensionList { get; set; }
+        public string FullPath { get; set; }
 
 		public override string ToString()
 		{

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -13,7 +13,8 @@ namespace PrivateGalleryCreator
     private static string _dir;
     private static string _galleryName;
     private static bool _recursive = false;
-    internal static string _outputFile;
+    private static string _outputFile;
+    private static string _exclude = string.Empty;
 
     private static void Main(string[] args)
     {
@@ -21,7 +22,9 @@ namespace PrivateGalleryCreator
 
       _recursive = args.Any(a => a == "--recursive");
 
-      _outputFile = args.FirstOrDefault(a => a.StartsWith("--output="))?.Replace("--output=", string.Empty) ?? Path.Combine(_dir, _xmlFileName); ;
+      _outputFile = args.FirstOrDefault(a => a.StartsWith("--output="))?.Replace("--output=", string.Empty) ?? Path.Combine(_dir, _xmlFileName);
+
+      _exclude = args.FirstOrDefault(a => a.StartsWith("--exclude="))?.Replace("--exclude=", string.Empty) ?? string.Empty;
 
       _galleryName = args.FirstOrDefault(a => a.StartsWith("--name="))?.Replace("--name=", string.Empty) ?? "VSIX Gallery";
 
@@ -75,7 +78,7 @@ namespace PrivateGalleryCreator
 
     private static void GenerateAtomFeed()
     {
-      IEnumerable<Package> packages = EnumerateFilesSafe(new DirectoryInfo(_dir), "*.vsix", _recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly).Distinct()
+      IEnumerable<Package> packages = EnumerateFilesSafe(new DirectoryInfo(_dir), "*.vsix", _recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly).Distinct().Where(f => !f.FullName.Contains(_exclude))
                                           .Select(f => ProcessVsix(f.FullName));
 
       var writer = new FeedWriter(_galleryName);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -12,10 +12,16 @@ namespace PrivateGalleryCreator
     private const string _xmlFileName = "feed.xml";
     private static string _dir;
     private static string _galleryName;
+    private static bool _recursive = false;
+    internal static string _outputFile;
 
     private static void Main(string[] args)
     {
-      _dir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+      _dir = args.FirstOrDefault(a => a.StartsWith("--input="))?.Replace("--input=", string.Empty) ?? Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+
+      _recursive = args.Any(a => a == "--recursive");
+
+      _outputFile = args.FirstOrDefault(a => a.StartsWith("--output="))?.Replace("--output=", string.Empty) ?? Path.Combine(_dir, _xmlFileName); ;
 
       _galleryName = args.FirstOrDefault(a => a.StartsWith("--name="))?.Replace("--name=", string.Empty) ?? "VSIX Gallery";
 
@@ -69,11 +75,11 @@ namespace PrivateGalleryCreator
 
     private static void GenerateAtomFeed()
     {
-      IEnumerable<Package> packages = Directory.EnumerateFiles(_dir, "*.vsix", SearchOption.TopDirectoryOnly)
-                                          .Select(f => ProcessVsix(f));
+      IEnumerable<Package> packages = EnumerateFilesSafe(new DirectoryInfo(_dir), "*.vsix", _recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly).Distinct()
+                                          .Select(f => ProcessVsix(f.FullName));
 
       var writer = new FeedWriter(_galleryName);
-      string feedUrl = Path.Combine(_dir, _xmlFileName);
+      string feedUrl = _outputFile;
       string xml = writer.GetFeed(feedUrl, packages);
 
       File.WriteAllText(feedUrl, xml, Encoding.UTF8);
@@ -98,7 +104,7 @@ namespace PrivateGalleryCreator
 
         if (!string.IsNullOrEmpty(package.Icon))
         {
-          string currentDir = Path.GetDirectoryName(sourceVsixPath);
+          string currentDir = Path.GetDirectoryName(_outputFile);
           string sourceIconPath = Path.Combine(tempFolder, package.Icon);
 
           if (File.Exists(sourceIconPath))
@@ -124,6 +130,48 @@ namespace PrivateGalleryCreator
       {
         Directory.Delete(tempFolder, true);
       }
+    }
+
+    public static IEnumerable<FileInfo> EnumerateFilesSafe(DirectoryInfo dir, string filter = "*.*", SearchOption opt = SearchOption.TopDirectoryOnly)
+    {
+      var retval = Enumerable.Empty<FileInfo>();
+
+      try
+      {
+        retval = dir.EnumerateFiles(filter, SearchOption.TopDirectoryOnly);
+      }
+      catch
+      {
+        Console.WriteLine("{0} Inaccessable.", dir.FullName);
+      }
+
+      if (opt == SearchOption.AllDirectories)
+      {
+        retval = retval.Concat(EnumerateDirectoriesSafe(dir, opt: opt).SelectMany(x => EnumerateFilesSafe(x, filter, SearchOption.TopDirectoryOnly)));
+      }
+
+      return retval;
+    }
+
+    public static IEnumerable<DirectoryInfo> EnumerateDirectoriesSafe(DirectoryInfo dir, string filter = "*.*", SearchOption opt = SearchOption.TopDirectoryOnly)
+    {
+      var retval = Enumerable.Empty<DirectoryInfo>();
+
+      try
+      {
+        retval = dir.EnumerateDirectories(filter, SearchOption.TopDirectoryOnly);
+      }
+      catch
+      {
+        Console.WriteLine("{0} Inaccessable.", dir.FullName);
+      }
+
+      if (opt == SearchOption.AllDirectories)
+      {
+        retval = retval.Concat(retval.SelectMany(x => EnumerateDirectoriesSafe(x, filter, opt)));
+      }
+
+      return retval;
     }
   }
 }

--- a/src/VsixManifestParser.cs
+++ b/src/VsixManifestParser.cs
@@ -100,7 +100,7 @@ namespace PrivateGalleryCreator
 			XmlNodeList list = doc.GetElementsByTagName("InstallationTarget");
 
 			if (list.Count == 0)
-				list = doc.GetElementsByTagName("<VisualStudio");
+				list = doc.GetElementsByTagName("VisualStudio");
 
 			var versions = new List<string>();
 


### PR DESCRIPTION
To aid automatic usage of the tool from CI, I added a few options (fixing #4 )

--input : to specify the dir_ to look at
--output : to specify the folder and filename of the feed.xml created
--recursive : to specify whether I need to remove TopDirectoryOnly and to dive into subdirectories as well
--exclude: specify path to be excluded

---------------------

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE:
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
ONLY THE SOFTWARE CODE AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS SOFTWARE, IF ANY, THAT ARE ATTACHED TO (OR OTHERWISE ACCOMPANY) THIS SUBMISSION (AND ORDINARY COURSE CONTRIBUTIONS OF FUTURES PATCHES THERETO) ARE TO BE CONSIDERED A CONTRIBUTION.  NO OTHER SOFTWARE CODE OR MATERIALS ARE A CONTRIBUTION. 
