### PR TITLE
Added --source option to set vsix download path

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ If you would like to have the particular folders, filenames skipped (instead of 
 PrivateGalleryCreator.exe --exclude=dontwantthis
 ```
 
+## Source option
+Be default, the download source path used in the gallery will be the location where the .vsix files reside when running the PrivateGalleryCreator. If you intend to move the .vsix files after creating the feed, you can specify the intended download source path with the --source option:
+
+```cmd
+PrivateGalleryCreator.exe --source=c:\your\vsix\repository\
+```
+
 ## Good to know
 
 * Run the *PrivateGalleryCreator.exe* every time you add or update a .vsix in the directory

--- a/src/Package.cs
+++ b/src/Package.cs
@@ -1,15 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace PrivateGalleryCreator
 {
 	public class Package
     {
-        public Package(string fileName)
+        public Package(string fileName, string fullSourcePath)
         {
-            FullPath = fileName;
-            FileName = Path.GetFileName(fileName);
+            FileName = fileName;
+            FullPath = fullSourcePath;
         }
 
         public string FileName { get; set; }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -16,6 +16,11 @@ namespace PrivateGalleryCreator
     private static string _outputFile;
     private static string _exclude = string.Empty;
 
+    /// <summary>
+    /// When not empty, this folder path will be used as download source for the extensions.
+    /// </summary>
+    private static string _source;
+
     private static void Main(string[] args)
     {
       _dir = args.FirstOrDefault(a => a.StartsWith("--input="))?.Replace("--input=", string.Empty) ?? Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
@@ -27,6 +32,8 @@ namespace PrivateGalleryCreator
       _exclude = args.FirstOrDefault(a => a.StartsWith("--exclude="))?.Replace("--exclude=", string.Empty) ?? string.Empty;
 
       _galleryName = args.FirstOrDefault(a => a.StartsWith("--name="))?.Replace("--name=", string.Empty) ?? "VSIX Gallery";
+
+      _source = args.FirstOrDefault(a => a.StartsWith("--source="))?.Replace("--source=", string.Empty) ?? string.Empty;
 
       GenerateAtomFeed();
 
@@ -101,8 +108,10 @@ namespace PrivateGalleryCreator
         Directory.CreateDirectory(tempFolder);
         ZipFile.ExtractToDirectory(sourceVsixPath, tempFolder);
 
+        var vsixFile = Path.GetFileName(sourceVsixPath);
+        var vsixSourcePath = string.IsNullOrEmpty(_source) ? sourceVsixPath : Path.Combine(_source, vsixFile);
         var parser = new VsixManifestParser();
-        Package package = parser.CreateFromManifest(tempFolder, sourceVsixPath);
+        Package package = parser.CreateFromManifest(tempFolder, vsixFile, vsixSourcePath);
 
 
         if (!string.IsNullOrEmpty(package.Icon))

--- a/src/VsixManifestParser.cs
+++ b/src/VsixManifestParser.cs
@@ -11,7 +11,7 @@ namespace PrivateGalleryCreator
 {
     public class VsixManifestParser
 	{
-		public Package CreateFromManifest(string tempFolder, string vsixFileName)
+		public Package CreateFromManifest(string tempFolder, string vsixFileName, string vsixSource)
 		{
 			string xml = File.ReadAllText(Path.Combine(tempFolder, "extension.vsixmanifest"));
 			xml = Regex.Replace(xml, "( xmlns(:\\w+)?)=\"([^\"]+)\"", string.Empty);
@@ -19,7 +19,7 @@ namespace PrivateGalleryCreator
 			var doc = new XmlDocument();
 			doc.LoadXml(xml);
 
-			var package = new Package(vsixFileName);
+			var package = new Package(vsixFileName, vsixSource);
 
 			if (doc.GetElementsByTagName("DisplayName").Count > 0)
 			{


### PR DESCRIPTION
Use case: We are building our Visual Studio extensions on a build server and run the PrivateGalleryCreator there. Only after all VSIX and the feed.xml have been created on the build server, the output is published to some network share. For this, we need the option to set the download source to something different (i.e. the final network share) than the location where the VSIX reside when the PrivateGalleryCreator runs.

Greetings,

Andree