### PR TITLE
Adding --latest-only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,24 @@ PrivateGalleryCreator.exe --exclude=dontwantthis
 ```
 
 ## Source option
-Be default, the download source path used in the gallery will be the location where the .vsix files reside when running the PrivateGalleryCreator. If you intend to move the .vsix files after creating the feed, you can specify the intended download source path with the --source option:
+By default, the download source path used in the gallery will be the location where the .vsix files reside when running the PrivateGalleryCreator. If you intend to move the .vsix files after creating the feed, you can specify the intended download source path with the --source option:
 
 ```cmd
 PrivateGalleryCreator.exe --source=c:\your\vsix\repository\
+```
+
+## Terminate option
+If you would like the application to exit immediately after processing VSIX files, use the --terminate option:
+
+```cmd
+PrivateGalleryCreator.exe --terminate
+```
+
+## Latest only option
+By default, any duplicate packages that are found will be processed, resulting in multiple versions of the same package in the feed. If you have a folder structure that retains previous versions of the packages, use the --latest-only option:
+
+```cmd
+PrivateGalleryCreator.exe --latest-only
 ```
 
 ## Good to know


### PR DESCRIPTION
Use case:

Our build pipeline places packages in folders by name/version number. Because of this, older package versions are retained in the same folder path as older versions.
Adding `--latest-version` option to only add the highest version number of packages that share the same ID to the feed.

Also updated some missing items from the README.