### PR TITLE
Fix AppVeyor after .NET Core

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ build_script:
 
 artifacts:
   - path: 'src\bin\$(configuration)\netcoreapp3.1\publish'
-    name: Executable
+    name: PrivateGalleryCreator

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,19 @@
 image: Visual Studio 2019
 version: 1.0.{build}
 configuration: Release
+
+dotnet_csproj:
+  patch: true
+  file: ./src/PrivateGalleryCreator.csproj
+  version: '{version}'
+
+before_build:
+  - cmd: dotnet --version
+  - cmd: dotnet restore ./src/PrivateGalleryCreator.csproj --verbosity m
+
 build_script:
-  - ps: ./build.ps1
+  - cmd: dotnet publish ./src/PrivateGalleryCreator.csproj
 
 artifacts:
-  - path: 'src\bin\**\*.exe'
+  - path: 'src\bin\$(configuration)\netcoreapp3.1\publish'
     name: Executable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ configuration: Release
 
 dotnet_csproj:
   patch: true
-  file: ./src/PrivateGalleryCreator.csproj
+  file: './src/PrivateGalleryCreator.csproj'
   version: '{version}'
 
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,15 +4,15 @@ configuration: Release
 
 dotnet_csproj:
   patch: true
-  file: './src/PrivateGalleryCreator.csproj'
+  file: 'src\PrivateGalleryCreator.csproj'
   version: '{version}'
 
 before_build:
   - cmd: dotnet --version
-  - cmd: dotnet restore ./src/PrivateGalleryCreator.csproj --verbosity m
+  - cmd: dotnet restore src\PrivateGalleryCreator.csproj --verbosity m
 
 build_script:
-  - cmd: dotnet publish ./src/PrivateGalleryCreator.csproj
+  - cmd: dotnet publish src\PrivateGalleryCreator.csproj
 
 artifacts:
   - path: 'src\bin\$(configuration)\netcoreapp3.1\publish'

--- a/src/PrivateGalleryCreator.csproj
+++ b/src/PrivateGalleryCreator.csproj
@@ -6,6 +6,12 @@
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />
+    <Version>1.0.0</Version>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
At the moment, the only artifact published to AppVeyor is the .exe, which is only one of four files needed for a .NET Core 3.1 app.
This should sort that, instead lumping all the necessary files into a single .zip file.