### PR TITLE
Fix for #7 time format forcing colon instead of culture-specific symbol

### DIFF
--- a/src/FeedWriter.cs
+++ b/src/FeedWriter.cs
@@ -29,7 +29,7 @@ namespace PrivateGalleryCreator
 
                 writer.WriteElementString("title", galleryTitle);
                 writer.WriteElementString("id", "5a7c2525-ddd8-4c44-b2e3-f57ba01a0d81");
-                writer.WriteElementString("updated", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+                writer.WriteElementString("updated", DateTime.UtcNow.ToString("yyyy-MM-ddTHH\\:mm\\:ssZ"));
                 writer.WriteElementString("subtitle", "Add this feed to Visual Studio's extension manager from Tools -> Options -> Environment -> Extensions and Updates");
 
                 writer.WriteStartElement("link");
@@ -69,8 +69,8 @@ namespace PrivateGalleryCreator
             writer.WriteValue(package.Description);
             writer.WriteEndElement(); // summary
 
-            writer.WriteElementString("published", package.DatePublished.ToString("yyyy-MM-ddTHH:mm:ssZ"));
-            writer.WriteElementString("updated", package.DatePublished.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+            writer.WriteElementString("published", package.DatePublished.ToString("yyyy-MM-ddTHH\\:mm\\:ssZ"));
+            writer.WriteElementString("updated", package.DatePublished.ToString("yyyy-MM-ddTHH\\:mm\\:ssZ"));
 
             writer.WriteStartElement("author");
             writer.WriteElementString("name", package.Author);


### PR DESCRIPTION
The ":" format specifier has a special meaning on custom date and time format strings as;

    replace me with current culture or supplied culture time separator.

[StackOverflow](https://stackoverflow.com/a/53903702/245748)


So in our case it's replaced with a dot and Visual Studio seems to expect a colon. So now it's forced to always be a colon (":") regardless of a culture.