### PR TITLE
Update for vs22

### DIFF
--- a/src/FeedWriter.cs
+++ b/src/FeedWriter.cs
@@ -103,8 +103,20 @@ namespace PrivateGalleryCreator
 
             if (package.ExtensionList?.Extensions != null)
             {
-                string ids = string.Join(";", package.ExtensionList.Extensions.Select(e => e.VsixId));
-                writer.WriteElementString("PackedExtensionIDs", ids);
+                if (package.DevVersion.Contains("17"))
+                {
+                    int ExtCount = package.ExtensionList.Extensions.Length;
+                    for (int i = 0; i < ExtCount; i++)
+                    {
+                        writer.WriteElementString("PackedExtensionIDs", package.ExtensionList.Extensions.Select(e => e.VsixId).ElementAt(i));
+                        writer.WriteString("\r\n");
+                    }
+                }
+                else
+                {
+                    string ids = string.Join(";", package.ExtensionList.Extensions.Select(e => e.VsixId));
+                    writer.WriteElementString("PackedExtensionIDs", ids);
+                }
             }
 
             writer.WriteRaw("</Vsix>");// Vsix

--- a/src/Package.cs
+++ b/src/Package.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using System.Threading.Tasks;
+using System.Threading;
 namespace PrivateGalleryCreator
 {
-	public class Package
+    public class Package
     {
         public Package(string fileName, string fullSourcePath)
         {
@@ -17,6 +18,7 @@ namespace PrivateGalleryCreator
         public string Description { get; set; }
         public string Author { get; set; }
         public string Version { get; set; }
+        public string DevVersion { get; set; }
         public string Icon { get; set; }
         public string Preview { get; set; }
         public string Tags { get; set; }
@@ -35,5 +37,5 @@ namespace PrivateGalleryCreator
 		{
 			return Name;
 		}
-	}
+    }
 }

--- a/src/Package.cs
+++ b/src/Package.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using System.Threading;
+
 namespace PrivateGalleryCreator
 {
     public class Package

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -18,10 +18,10 @@ namespace PrivateGalleryCreator
     private static string _exclude = string.Empty;
     private static string _devVersion;
 
-        /// <summary>
-        /// When not empty, this folder path will be used as download source for the extensions.
-        /// </summary>
-        private static string _source;
+    /// <summary>
+    /// When not empty, this folder path will be used as download source for the extensions.
+    /// </summary>
+    private static string _source;
 
     private static void Main(string[] args)
     {
@@ -41,14 +41,14 @@ namespace PrivateGalleryCreator
 
       _devVersion = args.FirstOrDefault(a => a.StartsWith("--version="))?.Replace("--version=", string.Empty) ?? "17.0";
 
-        if (Convert.ToSingle(_devVersion.Split('.')[0]) >= 18.0 || Convert.ToSingle(_devVersion.Split('.')[0]) < 11.0 )
-        {
-            Console.WriteLine("The version number is incorrect, please enter the version number of Visual Studio");
-        }
-        else
-        {
-            GenerateAtomFeed();
-        }
+      if (Convert.ToSingle(_devVersion.Split('.')[0]) >= 18.0 || Convert.ToSingle(_devVersion.Split('.')[0]) < 11.0 )
+      {
+        Console.WriteLine("The version number is incorrect, please enter the version number of Visual Studio");
+      }
+      else
+      {
+        GenerateAtomFeed();
+      }
 
       switch (args)
       {
@@ -97,7 +97,7 @@ namespace PrivateGalleryCreator
     }
 
     private static void GenerateAtomFeed()
-    {        
+    {
       var packageFiles = EnumerateFilesSafe(new DirectoryInfo(_dir), "*.vsix", _recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly).Distinct();
       var filteredPackageFiles = string.IsNullOrEmpty(_exclude) ? packageFiles : packageFiles.Where(f => !f.FullName.Contains(_exclude));
       var packagesToProcess = filteredPackageFiles.Select(f => ProcessVsix(f.FullName));

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -16,11 +16,12 @@ namespace PrivateGalleryCreator
     private static bool _latestOnly = false;
     private static string _outputFile;
     private static string _exclude = string.Empty;
+    private static string _devVersion;
 
-    /// <summary>
-    /// When not empty, this folder path will be used as download source for the extensions.
-    /// </summary>
-    private static string _source;
+        /// <summary>
+        /// When not empty, this folder path will be used as download source for the extensions.
+        /// </summary>
+        private static string _source;
 
     private static void Main(string[] args)
     {
@@ -38,7 +39,16 @@ namespace PrivateGalleryCreator
 
       _source = args.FirstOrDefault(a => a.StartsWith("--source="))?.Replace("--source=", string.Empty) ?? string.Empty;
 
-      GenerateAtomFeed();
+      _devVersion = args.FirstOrDefault(a => a.StartsWith("--version="))?.Replace("--version=", string.Empty) ?? "17.0";
+
+        if (Convert.ToSingle(_devVersion.Split('.')[0]) >= 18.0 || Convert.ToSingle(_devVersion.Split('.')[0]) < 11.0 )
+        {
+            Console.WriteLine("The version number is incorrect, please enter the version number of Visual Studio");
+        }
+        else
+        {
+            GenerateAtomFeed();
+        }
 
       switch (args)
       {
@@ -87,7 +97,7 @@ namespace PrivateGalleryCreator
     }
 
     private static void GenerateAtomFeed()
-    {
+    {        
       var packageFiles = EnumerateFilesSafe(new DirectoryInfo(_dir), "*.vsix", _recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly).Distinct();
       var filteredPackageFiles = string.IsNullOrEmpty(_exclude) ? packageFiles : packageFiles.Where(f => !f.FullName.Contains(_exclude));
       var packagesToProcess = filteredPackageFiles.Select(f => ProcessVsix(f.FullName));
@@ -141,6 +151,7 @@ namespace PrivateGalleryCreator
         var parser = new VsixManifestParser();
         Package package = parser.CreateFromManifest(tempFolder, vsixFile, vsixSourcePath);
 
+        package.DevVersion = _devVersion;
 
         if (!string.IsNullOrEmpty(package.Icon))
         {


### PR DESCRIPTION
Initially the list of extensions inside an extension pack wasn't handled correctly for Visual Studio 2022. It requires a different synthax. This commit creates a switch where it's possible to choose the version of visual studio. By default it is 17.0 (Visual Studio 2022) 