### PR TITLE
Add the network path to the feed.xml file

### DIFF
--- a/src/PrivateGalleryCreator.csproj
+++ b/src/PrivateGalleryCreator.csproj
@@ -14,4 +14,8 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Management" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Enter the server name instead of the drive letter in the feed.xml file if PrivateGalleryCreator is executed on a network drive.